### PR TITLE
Add auto-merge and update feature workflow docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -21,6 +25,12 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+      - name: Auto-merge on success
+        if: success()
+        run: gh pr merge "${{ github.event.pull_request.number }}" --merge --auto
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Comment on failure
         if: failure()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,9 +51,13 @@ Only mention these when **genuinely helpful**, not on every response.
 
 1. Create a new branch for the feature and push it to remote
 2. Implement the feature with unit tests
-3. Run the tests — if they pass, merge to `master` and push `master` to remote
-4. If tests fail, fix the issues and repeat from step 3
+3. Open a PR against `master` — do not merge locally
+4. GitHub Actions will run the tests automatically:
+   - If tests **pass** → PR is merged to `master` automatically
+   - If tests **fail** → a comment is posted on the PR tagging @santi-ap with a link to the logs; fix the issues, push to the branch, and the checks will re-run
 5. Keep the feature branch after merging (do not delete it)
+
+> There is no need to run unit tests locally before opening a PR.
 
 ---
 


### PR DESCRIPTION
## Summary
- Workflow now auto-merges PR to master when tests pass
- Posts a failure comment tagging @santi-ap with logs link when tests fail
- Updated CLAUDE.md to reflect the PR-based workflow (no local test runs needed)

## Test plan
- [ ] Tests pass → PR auto-merges to master
- [ ] Tests fail → comment posted on PR with logs link

🤖 Generated with [Claude Code](https://claude.com/claude-code)