### PR TITLE
Fix notifications not firing on iOS

### DIFF
--- a/__tests__/alarmUtils.test.ts
+++ b/__tests__/alarmUtils.test.ts
@@ -3,9 +3,11 @@ import {
   getAlarmTimeslots,
   dayToWeekday,
   formatDays,
+  countNotifications,
   ALL_DAYS,
   WORKDAYS,
   WEEKENDS,
+  IOS_NOTIFICATION_LIMIT,
 } from '../utils/alarmUtils';
 
 describe('formatTime', () => {
@@ -69,6 +71,29 @@ describe('dayToWeekday', () => {
 
   it('converts Monday (1) to weekday 2', () => {
     expect(dayToWeekday(1)).toBe(2);
+  });
+});
+
+describe('countNotifications', () => {
+  it('counts slots only when all 7 days selected (daily trigger)', () => {
+    // 9:00–18:00 every 60 min = 10 slots, all days → 10 notifications (not 70)
+    expect(countNotifications({ startMinutes: 540, endMinutes: 1080, intervalMinutes: 60, days: ALL_DAYS })).toBe(10);
+  });
+
+  it('counts slots × days when specific days selected', () => {
+    // 9:00–10:00 every 60 min = 2 slots, 3 days → 6 notifications
+    expect(countNotifications({ startMinutes: 540, endMinutes: 600, intervalMinutes: 60, days: [1, 2, 3] })).toBe(6);
+  });
+
+  it('exceeds iOS limit for 5-min interval over a full day', () => {
+    // 9:00–18:00 every 5 min = 109 slots, all days → 109 > 64
+    const count = countNotifications({ startMinutes: 540, endMinutes: 1080, intervalMinutes: 5, days: ALL_DAYS });
+    expect(count).toBeGreaterThan(IOS_NOTIFICATION_LIMIT);
+  });
+
+  it('stays within iOS limit for 60-min interval all day', () => {
+    const count = countNotifications({ startMinutes: 540, endMinutes: 1080, intervalMinutes: 60, days: ALL_DAYS });
+    expect(count).toBeLessThanOrEqual(IOS_NOTIFICATION_LIMIT);
   });
 });
 

--- a/screens/AlarmFormScreen.tsx
+++ b/screens/AlarmFormScreen.tsx
@@ -17,7 +17,8 @@ import {
   WORKDAYS,
   WEEKENDS,
   DAY_LABELS,
-  getAlarmTimeslots,
+  IOS_NOTIFICATION_LIMIT,
+  countNotifications,
 } from '../utils/alarmUtils';
 import type { Alarm, AlarmFormScreenProps } from '../types';
 
@@ -49,7 +50,8 @@ export default function AlarmFormScreen({ route, navigation }: AlarmFormScreenPr
   const [showEnd, setShowEnd] = useState(false);
   const [saving, setSaving] = useState(false);
 
-  const alertCount = getAlarmTimeslots({ startMinutes, endMinutes, intervalMinutes }).length;
+  const alertCount = countNotifications({ startMinutes, endMinutes, intervalMinutes, days });
+  const overLimit = alertCount > IOS_NOTIFICATION_LIMIT;
 
   function toggleDay(day: number) {
     setDays((prev) =>
@@ -223,14 +225,19 @@ export default function AlarmFormScreen({ route, navigation }: AlarmFormScreenPr
         </View>
       </View>
 
-      <View style={styles.previewBox}>
-        <Text style={styles.previewTitle}>
+      <View style={[styles.previewBox, overLimit && styles.previewBoxWarning]}>
+        <Text style={[styles.previewTitle, overLimit && styles.previewTitleWarning]}>
           {alertCount} alert{alertCount !== 1 ? 's' : ''} per day
         </Text>
         <Text style={styles.previewSub}>
           {formatTime(startMinutes)} · every {intervalMinutes} min · until{' '}
           {formatTime(endMinutes)}
         </Text>
+        {overLimit && (
+          <Text style={styles.previewWarning}>
+            ⚠️ Exceeds iOS limit of {IOS_NOTIFICATION_LIMIT}. Only the first {IOS_NOTIFICATION_LIMIT} alerts will fire. Use a longer interval or shorter range.
+          </Text>
+        )}
       </View>
 
       <Pressable
@@ -345,8 +352,11 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: 4,
   },
+  previewBoxWarning: { backgroundColor: '#FFF4E5' },
   previewTitle: { fontSize: 18, fontWeight: '700', color: '#4A90E2' },
+  previewTitleWarning: { color: '#E07800' },
   previewSub: { fontSize: 13, color: '#666' },
+  previewWarning: { fontSize: 12, color: '#E07800', textAlign: 'center', marginTop: 4 },
   saveBtn: {
     backgroundColor: '#4A90E2',
     borderRadius: 14,

--- a/utils/alarmUtils.ts
+++ b/utils/alarmUtils.ts
@@ -1,5 +1,8 @@
 import type { Alarm } from '../types';
 
+/** iOS hard cap on pending scheduled notifications. */
+export const IOS_NOTIFICATION_LIMIT = 64;
+
 export const ALL_DAYS = [0, 1, 2, 3, 4, 5, 6];
 export const WORKDAYS = [1, 2, 3, 4, 5];
 export const WEEKENDS = [0, 6];
@@ -31,6 +34,17 @@ export function getAlarmTimeslots(alarm: Pick<Alarm, 'startMinutes' | 'endMinute
 /** Our day index (0=Sun … 6=Sat) → expo-notifications weekday (1=Sun … 7=Sat) */
 export function dayToWeekday(day: number): number {
   return day + 1;
+}
+
+/**
+ * Total notifications that would be scheduled for this alarm.
+ * When all 7 days are selected we use a daily trigger (no weekday),
+ * so the count equals the number of time slots. Otherwise it's slots × days.
+ */
+export function countNotifications(alarm: Pick<Alarm, 'startMinutes' | 'endMinutes' | 'intervalMinutes' | 'days'>): number {
+  const slots = getAlarmTimeslots(alarm).length;
+  const days = alarm.days ?? ALL_DAYS;
+  return days.length === ALL_DAYS.length ? slots : slots * days.length;
 }
 
 /** Human-readable summary of selected days, e.g. "Workdays", "Mo, We, Fr" */

--- a/utils/notifications.ts
+++ b/utils/notifications.ts
@@ -1,7 +1,7 @@
 import * as Notifications from 'expo-notifications';
 import { Platform } from 'react-native';
 import type { Alarm } from '../types';
-import { ALL_DAYS, dayToWeekday, formatTime, getAlarmTimeslots } from './alarmUtils';
+import { ALL_DAYS, IOS_NOTIFICATION_LIMIT, dayToWeekday, formatTime, getAlarmTimeslots } from './alarmUtils';
 
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
@@ -39,14 +39,18 @@ export async function scheduleAlarmNotifications(alarm: Alarm): Promise<string[]
 
   const { label } = alarm;
   const days = alarm.days ?? ALL_DAYS;
+  const allDays = days.length === ALL_DAYS.length;
   const slots = getAlarmTimeslots(alarm);
   const notificationIds: string[] = [];
+  let scheduled = 0;
 
   for (const slot of slots) {
     const hour = Math.floor(slot / 60);
     const minute = slot % 60;
 
-    for (const day of days) {
+    if (allDays) {
+      // Daily repeat — one notification per slot, no weekday needed
+      if (scheduled >= IOS_NOTIFICATION_LIMIT) break;
       const id = await Notifications.scheduleNotificationAsync({
         content: {
           title: label || 'Interval Alarm',
@@ -55,15 +59,36 @@ export async function scheduleAlarmNotifications(alarm: Alarm): Promise<string[]
         },
         trigger: {
           type: Notifications.SchedulableTriggerInputTypes.CALENDAR,
-          weekday: dayToWeekday(day),
           hour,
           minute,
           repeats: true,
           ...(Platform.OS === 'android' && { channelId: 'interval-alarms' }),
         },
       });
-
       notificationIds.push(id);
+      scheduled++;
+    } else {
+      for (const day of days) {
+        if (scheduled >= IOS_NOTIFICATION_LIMIT) break;
+        const id = await Notifications.scheduleNotificationAsync({
+          content: {
+            title: label || 'Interval Alarm',
+            body: formatTime(slot),
+            sound: 'default',
+          },
+          trigger: {
+            type: Notifications.SchedulableTriggerInputTypes.CALENDAR,
+            weekday: dayToWeekday(day),
+            hour,
+            minute,
+            repeats: true,
+            ...(Platform.OS === 'android' && { channelId: 'interval-alarms' }),
+          },
+        });
+        notificationIds.push(id);
+        scheduled++;
+      }
+      if (scheduled >= IOS_NOTIFICATION_LIMIT) break;
     }
   }
 


### PR DESCRIPTION
## Summary
- When all 7 days are selected, scheduling now uses a daily repeat trigger (no `weekday`) — this reduces notification count from `slots × 7` down to just `slots`, fixing the iOS 64 cap being blown through silently
- Added a hard cap at 64 during scheduling so the OS never silently drops notifications
- AlarmFormScreen now shows an orange warning when the alarm configuration would exceed the iOS limit

## Root cause
A 5-min interval alarm from 9am–6pm = 109 slots × 7 days = 763 notifications scheduled. iOS silently keeps only the 64 soonest, so most never fired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)