### PR TITLE
Add keyboard and time picker dismiss controls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,11 @@ npm run android    # Start with Android emulator
 npm run ios        # Start with iOS simulator
 ```
 
-No test runner or linter is configured.
+```bash
+npm test           # Run unit tests
+```
+
+**iOS testing limitation:** `expo-notifications` is not fully supported in Expo Go on iOS. A development build is required, which needs an Apple Developer account ($99/year) and macOS. Without these, notifications cannot be tested on a physical iPhone.
 
 ---
 

--- a/screens/AlarmFormScreen.tsx
+++ b/screens/AlarmFormScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import {
   Alert,
+  Keyboard,
   Platform,
   Pressable,
   ScrollView,
@@ -106,6 +107,8 @@ export default function AlarmFormScreen({ route, navigation }: AlarmFormScreenPr
           value={label}
           onChangeText={setLabel}
           maxLength={40}
+          returnKeyType="done"
+          onSubmitEditing={Keyboard.dismiss}
         />
       </View>
 
@@ -125,29 +128,43 @@ export default function AlarmFormScreen({ route, navigation }: AlarmFormScreenPr
       </View>
 
       {showStart && (
-        <DateTimePicker
-          value={minutesToDate(startMinutes)}
-          mode="time"
-          is24Hour={false}
-          display={Platform.OS === 'ios' ? 'spinner' : 'default'}
-          onChange={(_: DateTimePickerEvent, date?: Date) => {
-            setShowStart(Platform.OS === 'ios');
-            if (date) setStartMinutes(dateToMinutes(date));
-          }}
-        />
+        <View style={styles.pickerContainer}>
+          {Platform.OS === 'ios' && (
+            <Pressable style={styles.pickerDoneBtn} onPress={() => setShowStart(false)}>
+              <Text style={styles.pickerDoneText}>Done</Text>
+            </Pressable>
+          )}
+          <DateTimePicker
+            value={minutesToDate(startMinutes)}
+            mode="time"
+            is24Hour={false}
+            display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+            onChange={(_: DateTimePickerEvent, date?: Date) => {
+              setShowStart(Platform.OS === 'ios');
+              if (date) setStartMinutes(dateToMinutes(date));
+            }}
+          />
+        </View>
       )}
 
       {showEnd && (
-        <DateTimePicker
-          value={minutesToDate(endMinutes)}
-          mode="time"
-          is24Hour={false}
-          display={Platform.OS === 'ios' ? 'spinner' : 'default'}
-          onChange={(_: DateTimePickerEvent, date?: Date) => {
-            setShowEnd(Platform.OS === 'ios');
-            if (date) setEndMinutes(dateToMinutes(date));
-          }}
-        />
+        <View style={styles.pickerContainer}>
+          {Platform.OS === 'ios' && (
+            <Pressable style={styles.pickerDoneBtn} onPress={() => setShowEnd(false)}>
+              <Text style={styles.pickerDoneText}>Done</Text>
+            </Pressable>
+          )}
+          <DateTimePicker
+            value={minutesToDate(endMinutes)}
+            mode="time"
+            is24Hour={false}
+            display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+            onChange={(_: DateTimePickerEvent, date?: Date) => {
+              setShowEnd(Platform.OS === 'ios');
+              if (date) setEndMinutes(dateToMinutes(date));
+            }}
+          />
+        </View>
       )}
 
       <View style={styles.section}>
@@ -278,6 +295,18 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 2 },
     elevation: 1,
   },
+  pickerContainer: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    overflow: 'hidden',
+  },
+  pickerDoneBtn: {
+    alignItems: 'flex-end',
+    paddingHorizontal: 16,
+    paddingTop: 12,
+    paddingBottom: 4,
+  },
+  pickerDoneText: { fontSize: 16, fontWeight: '600', color: '#4A90E2' },
   timeLabel: { fontSize: 11, color: '#999', fontWeight: '600', marginBottom: 4 },
   timeValue: { fontSize: 22, fontWeight: '700', color: '#4A90E2' },
   timeDash: { fontSize: 18, color: '#bbb' },


### PR DESCRIPTION
## Summary
- Label input now shows a **Done** key on the iOS keyboard; tapping it dismisses the keyboard
- Time pickers on iOS now show a **Done** button above the spinner; tapping it hides the picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)