### PR TITLE
fix: schedule same-day notifications for weekday-specific alarms

### DIFF
--- a/__tests__/alarmUtils.test.ts
+++ b/__tests__/alarmUtils.test.ts
@@ -4,6 +4,7 @@ import {
   dayToWeekday,
   formatDays,
   countNotifications,
+  getSameDayUpcomingSlots,
   ALL_DAYS,
   WORKDAYS,
   WEEKENDS,
@@ -94,6 +95,40 @@ describe('countNotifications', () => {
   it('stays within iOS limit for 60-min interval all day', () => {
     const count = countNotifications({ startMinutes: 540, endMinutes: 1080, intervalMinutes: 60, days: ALL_DAYS });
     expect(count).toBeLessThanOrEqual(IOS_NOTIFICATION_LIMIT);
+  });
+});
+
+describe('getSameDayUpcomingSlots', () => {
+  const alarm = { startMinutes: 540, endMinutes: 660, intervalMinutes: 60, days: [1, 3, 5] }; // Mon/Wed/Fri, 9–11 AM
+
+  it('returns upcoming slots when today is a selected day', () => {
+    // 9:30 AM on Monday → 9:00 passed, 10:00 and 11:00 upcoming
+    expect(getSameDayUpcomingSlots(alarm, 570, 1)).toEqual([600, 660]);
+  });
+
+  it('returns all slots when none have passed yet', () => {
+    // 8:00 AM on Monday → all slots upcoming
+    expect(getSameDayUpcomingSlots(alarm, 480, 1)).toEqual([540, 600, 660]);
+  });
+
+  it('returns empty when all slots have passed', () => {
+    // 12:00 PM on Monday → all slots passed
+    expect(getSameDayUpcomingSlots(alarm, 720, 1)).toEqual([]);
+  });
+
+  it('returns empty when today is not a selected day', () => {
+    // Sunday (0) is not in [1, 3, 5]
+    expect(getSameDayUpcomingSlots(alarm, 480, 0)).toEqual([]);
+  });
+
+  it('returns upcoming slots for an all-days alarm', () => {
+    const allDaysAlarm = { startMinutes: 540, endMinutes: 660, intervalMinutes: 60, days: ALL_DAYS };
+    expect(getSameDayUpcomingSlots(allDaysAlarm, 570, 2)).toEqual([600, 660]);
+  });
+
+  it('returns empty for all-days alarm when all slots have passed', () => {
+    const allDaysAlarm = { startMinutes: 540, endMinutes: 660, intervalMinutes: 60, days: ALL_DAYS };
+    expect(getSameDayUpcomingSlots(allDaysAlarm, 720, 2)).toEqual([]);
   });
 });
 

--- a/tasks/bug-fix-same-day-alarm.md
+++ b/tasks/bug-fix-same-day-alarm.md
@@ -1,0 +1,17 @@
+# Plan
+
+- [x] ## 🐞 BUG: Alarms do not go off on the same day they are created
+    - [x] ### Investigate Scheduling Logic
+        - [x] Review `utils/notifications.ts` to analyze how `scheduleAlarmNotifications` calculates trigger dates and times.
+        - [x] Focus on how the current date/time is compared to the alarm's start/end times.
+    - [x] ### Propose a Fix
+        - [x] Identify the logical error causing the same-day scheduling to be missed.
+        - [x] Propose a change to the date/time comparison to correctly include the current day.
+    - [x] ### Implement the Fix
+        - [x] Add `getSameDayUpcomingSlots` helper to `utils/alarmUtils.ts`.
+        - [x] Modify `utils/notifications.ts` to schedule one-time DATE triggers for upcoming same-day slots (weekday-specific alarms).
+    - [x] ### Write & Run Tests
+        - [x] Add `getSameDayUpcomingSlots` tests to `__tests__/alarmUtils.test.ts` (6 new test cases).
+        - [x] All 28 tests pass locally.
+    - [ ] ### Create PR
+        - [ ] Once tests pass, delegate Git operations to Gemini: `gemini --yolo "Tests passed. Please commit these changes and create a PR against master."`

--- a/utils/alarmUtils.ts
+++ b/utils/alarmUtils.ts
@@ -47,6 +47,21 @@ export function countNotifications(alarm: Pick<Alarm, 'startMinutes' | 'endMinut
   return days.length === ALL_DAYS.length ? slots : slots * days.length;
 }
 
+/**
+ * Returns timeslots (minutes since midnight) that are upcoming later today.
+ * Returns an empty array if today is not a selected day.
+ */
+export function getSameDayUpcomingSlots(
+  alarm: Pick<Alarm, 'startMinutes' | 'endMinutes' | 'intervalMinutes' | 'days'>,
+  currentMinutes: number,
+  todayDayIndex: number, // 0=Sun … 6=Sat
+): number[] {
+  const days = alarm.days ?? ALL_DAYS;
+  const todayIsSelected = days.length === ALL_DAYS.length || days.includes(todayDayIndex);
+  if (!todayIsSelected) return [];
+  return getAlarmTimeslots(alarm).filter((slot) => slot > currentMinutes);
+}
+
 /** Human-readable summary of selected days, e.g. "Workdays", "Mo, We, Fr" */
 export function formatDays(days: number[]): string {
   if (days.length === 7) return 'Every day';

--- a/utils/notifications.ts
+++ b/utils/notifications.ts
@@ -1,7 +1,7 @@
 import * as Notifications from 'expo-notifications';
 import { Platform } from 'react-native';
 import type { Alarm } from '../types';
-import { ALL_DAYS, IOS_NOTIFICATION_LIMIT, dayToWeekday, formatTime, getAlarmTimeslots } from './alarmUtils';
+import { ALL_DAYS, IOS_NOTIFICATION_LIMIT, dayToWeekday, formatTime, getAlarmTimeslots, getSameDayUpcomingSlots } from './alarmUtils';
 
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
@@ -43,6 +43,36 @@ export async function scheduleAlarmNotifications(alarm: Alarm): Promise<string[]
   const slots = getAlarmTimeslots(alarm);
   const notificationIds: string[] = [];
   let scheduled = 0;
+
+  // For weekday-specific alarms, CALENDAR weekday triggers may skip the current day.
+  // Schedule one-time DATE triggers for any slots still upcoming today.
+  if (!allDays) {
+    const now = new Date();
+    const currentMinutes = now.getHours() * 60 + now.getMinutes();
+    const todayDayIndex = now.getDay();
+    const sameDaySlots = getSameDayUpcomingSlots(alarm, currentMinutes, todayDayIndex);
+    for (const slot of sameDaySlots) {
+      if (scheduled >= IOS_NOTIFICATION_LIMIT) break;
+      const hour = Math.floor(slot / 60);
+      const minute = slot % 60;
+      const triggerDate = new Date();
+      triggerDate.setHours(hour, minute, 0, 0);
+      const id = await Notifications.scheduleNotificationAsync({
+        content: {
+          title: label || 'Interval Alarm',
+          body: formatTime(slot),
+          sound: 'default',
+        },
+        trigger: {
+          type: Notifications.SchedulableTriggerInputTypes.DATE,
+          date: triggerDate,
+          ...(Platform.OS === 'android' && { channelId: 'interval-alarms' }),
+        },
+      });
+      notificationIds.push(id);
+      scheduled++;
+    }
+  }
 
   for (const slot of slots) {
     const hour = Math.floor(slot / 60);


### PR DESCRIPTION
## Summary
- Add `getSameDayUpcomingSlots` helper to `utils/alarmUtils.ts` that returns timeslots still upcoming today for a given alarm
- Fix `utils/notifications.ts` to schedule one-time `DATE` triggers for same-day upcoming slots in weekday-specific alarms (the `allDays` CALENDAR trigger already fires correctly on the same day)
- Add 6 new test cases covering the new helper

## Root Cause
Weekday-specific alarms only used repeating `CALENDAR` triggers (`weekday + hour + minute`), which may skip the current day and only start firing from the next matching weekday.

## Test plan
- [x] 28/28 tests pass locally
- [x] New `getSameDayUpcomingSlots` tests cover: upcoming slots, all passed, none passed, day not selected, all-days alarm

🤖 Generated with [Claude Code](https://claude.com/claude-code)