### PR TITLE
feat: set up EAS Update for remote Expo Go access

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,5 +1,6 @@
 {
   "expo": {
+    "owner": "santi_ap",
     "name": "interval-alarm",
     "slug": "interval-alarm",
     "version": "1.0.0",
@@ -35,6 +36,17 @@
           "sounds": []
         }
       ]
-    ]
+    ],
+    "extra": {
+      "eas": {
+        "projectId": "a4a9474e-fb21-4695-a69c-1189a60c7912"
+      }
+    },
+    "runtimeVersion": {
+      "policy": "appVersion"
+    },
+    "updates": {
+      "url": "https://u.expo.dev/a4a9474e-fb21-4695-a69c-1189a60c7912"
+    }
   }
 }

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,18 @@
+{
+  "cli": {
+    "version": ">= 18.0.0"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {}
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "expo-device": "~8.0.10",
         "expo-notifications": "~0.32.16",
         "expo-status-bar": "~3.0.9",
+        "expo-updates": "~29.0.16",
         "react": "19.1.0",
         "react-native": "0.81.5",
         "react-native-safe-area-context": "~5.6.0",
@@ -5303,6 +5304,31 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-eas-client": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/expo-eas-client/-/expo-eas-client-1.0.8.tgz",
+      "integrity": "sha512-5or11NJhSeDoHHI6zyvQDW2cz/yFyE+1Cz8NTs5NK8JzC7J0JrkUgptWtxyfB6Xs/21YRNifd3qgbBN3hfKVgA==",
+      "license": "MIT"
+    },
+    "node_modules/expo-json-utils": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-0.15.0.tgz",
+      "integrity": "sha512-duRT6oGl80IDzH2LD2yEFWNwGIC2WkozsB6HF3cDYNoNNdUvFk6uN3YiwsTsqVM/D0z6LEAQ01/SlYvN+Fw0JQ==",
+      "license": "MIT"
+    },
+    "node_modules/expo-manifests": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-1.0.10.tgz",
+      "integrity": "sha512-oxDUnURPcL4ZsOBY6X1DGWGuoZgVAFzp6PISWV7lPP2J0r8u1/ucuChBgpK7u1eLGFp6sDIPwXyEUCkI386XSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~12.0.11",
+        "expo-json-utils": "~0.15.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-modules-autolinking": {
       "version": "3.0.24",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.24.tgz",
@@ -5373,6 +5399,57 @@
         "react": "*",
         "react-native": "*"
       }
+    },
+    "node_modules/expo-structured-headers": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/expo-structured-headers/-/expo-structured-headers-5.0.0.tgz",
+      "integrity": "sha512-RmrBtnSphk5REmZGV+lcdgdpxyzio5rJw8CXviHE6qH5pKQQ83fhMEcigvrkBdsn2Efw2EODp4Yxl1/fqMvOZw==",
+      "license": "MIT"
+    },
+    "node_modules/expo-updates": {
+      "version": "29.0.16",
+      "resolved": "https://registry.npmjs.org/expo-updates/-/expo-updates-29.0.16.tgz",
+      "integrity": "sha512-E9/fxRz/Eurtc7hxeI/6ZPyHH3To9Xoccm1kXoICZTRojmuTo+dx0Xv53UHyHn4G5zGMezyaKF2Qtj3AKcT93w==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/code-signing-certificates": "^0.0.6",
+        "@expo/plist": "^0.4.8",
+        "@expo/spawn-async": "^1.7.2",
+        "arg": "4.1.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.4",
+        "expo-eas-client": "~1.0.8",
+        "expo-manifests": "~1.0.10",
+        "expo-structured-headers": "~5.0.0",
+        "expo-updates-interface": "~2.0.0",
+        "getenv": "^2.0.0",
+        "glob": "^13.0.0",
+        "ignore": "^5.3.1",
+        "resolve-from": "^5.0.0"
+      },
+      "bin": {
+        "expo-updates": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-updates-interface": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-2.0.0.tgz",
+      "integrity": "sha512-pTzAIufEZdVPKql6iMi5ylVSPqV1qbEopz9G6TSECQmnNde2nwq42PxdFBaUEd8IZJ/fdJLQnOT3m6+XJ5s7jg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-updates/node_modules/arg": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
+      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
+      "license": "MIT"
     },
     "node_modules/expo/node_modules/@expo/cli": {
       "version": "54.0.23",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "expo-device": "~8.0.10",
     "expo-notifications": "~0.32.16",
     "expo-status-bar": "~3.0.9",
+    "expo-updates": "~29.0.16",
     "react": "19.1.0",
     "react-native": "0.81.5",
     "react-native-safe-area-context": "~5.6.0",

--- a/tasks/setup-eas-update.md
+++ b/tasks/setup-eas-update.md
@@ -1,0 +1,20 @@
+# Task: Set Up EAS Update for Expo Go (no PC needed)
+
+## Goal
+Publish the JS bundle to Expo's CDN so Expo Go can load the app remotely without a running dev server.
+
+## Steps
+
+- [x] 0. Create task file *(this file)*
+- [x] 1. Create an Expo account at https://expo.dev/signup
+- [x] 2. Install EAS CLI: `npm install -g eas-cli` *(eas-cli/18.3.0)*
+- [x] 3. Log in: `eas login`
+- [x] 4. Add `owner` field to `app.json` *(santi_ap)*
+- [x] 5. Run `eas build:configure` to generate `eas.json`
+- [x] 6. Publish first update: `eas update --branch production --message "initial publish"`
+- [x] 7. Open in Expo Go on phone (scan QR or enter URL)
+
+## Notes
+- Username from step 1 is needed for step 4
+- `eas build:configure` auto-generates `eas.json`
+- Future updates: `eas update --branch production --message "describe change"`


### PR DESCRIPTION
## Summary
- Add `owner` and EAS `projectId` to `app.json`
- Add `eas.json` build configuration
- Install `expo-updates` package
- Add task tracking file for setup steps

## Why
Enables loading the app in Expo Go from Expo's CDN without needing a running dev server on the PC. Future updates can be pushed with `eas update --branch production --message "..."`.

## Test plan
- [ ] Open Expo Go on phone and verify the app loads from the cloud (no dev server running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)