### PR TITLE
ci: add EAS Update workflow

### DIFF
--- a/.github/workflows/eas-update.yml
+++ b/.github/workflows/eas-update.yml
@@ -1,0 +1,28 @@
+name: EAS Update
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Publish EAS Update
+        run: eas update --channel production --message "${{ github.event.head_commit.message }}" --non-interactive


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/eas-update.yml` — publishes an OTA JS bundle to EAS `production` channel on every push to `master`
- Requires `EXPO_TOKEN` secret (already added)

## Test plan
- [ ] Merge → confirm `EAS Update` action runs in the Actions tab
- [ ] Open app on phone → confirm it receives the OTA update

🤖 Generated with [Claude Code](https://claude.com/claude-code)