### PR TITLE
feat: GitHub Projects kanban integration

### DIFF
--- a/.github/project-number
+++ b/.github/project-number
@@ -1,0 +1,2 @@
+# This file is written by scripts/setup-github-project.sh
+# Do not edit manually. Contains the GitHub Projects project number.

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,0 +1,111 @@
+name: Project Automation
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [master]
+
+permissions:
+  issues: read
+  pull-requests: read
+  # Note: 'project' scope cannot be granted here via GITHUB_TOKEN.
+  # This workflow requires a PAT (PROJECT_TOKEN) with 'project' scope
+  # stored as a repository secret.
+
+jobs:
+  move-to-done:
+    # Only run when the PR is actually merged (not just closed/rejected)
+    if: github.event.pull_request.merged == true
+
+    runs-on: ubuntu-latest
+
+    env:
+      GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+      OWNER: santi-ap
+      PROJECT_NUMBER_FILE: .github/project-number
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Extract issue numbers from PR body
+        id: issues
+        run: |
+          PR_BODY="${{ github.event.pull_request.body }}"
+          # Match "Closes #N", "Fixes #N", "Resolves #N" (case-insensitive)
+          ISSUE_NUMBERS=$(echo "$PR_BODY" \
+            | grep -oiE '(closes|fixes|resolves)\s+#[0-9]+' \
+            | grep -oE '[0-9]+' \
+            | tr '\n' ' ' \
+            | xargs)
+          echo "Found issue numbers: $ISSUE_NUMBERS"
+          echo "issue_numbers=$ISSUE_NUMBERS" >> "$GITHUB_OUTPUT"
+
+      - name: Read project number
+        id: project
+        run: |
+          if [[ ! -f "$PROJECT_NUMBER_FILE" ]]; then
+            echo "ERROR: $PROJECT_NUMBER_FILE not found."
+            exit 1
+          fi
+          PROJECT_NUMBER=$(cat "$PROJECT_NUMBER_FILE")
+          echo "project_number=$PROJECT_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch project metadata
+        id: metadata
+        run: |
+          PROJECT_NUMBER="${{ steps.project.outputs.project_number }}"
+
+          PROJECT_ID=$(gh project list --owner "$OWNER" --format json \
+            | jq -r --argjson num "$PROJECT_NUMBER" \
+                '.projects[] | select(.number == $num) | .id')
+
+          FIELDS=$(gh project field-list "$PROJECT_NUMBER" --owner "$OWNER" --format json)
+
+          STATUS_FIELD_ID=$(echo "$FIELDS" \
+            | jq -r '.fields[] | select(.name == "Status") | .id')
+
+          DONE_OPTION_ID=$(echo "$FIELDS" \
+            | jq -r '.fields[] | select(.name == "Status") | .options[] | select(.name == "Done") | .id')
+
+          echo "project_id=$PROJECT_ID"            >> "$GITHUB_OUTPUT"
+          echo "status_field_id=$STATUS_FIELD_ID"  >> "$GITHUB_OUTPUT"
+          echo "done_option_id=$DONE_OPTION_ID"    >> "$GITHUB_OUTPUT"
+
+      - name: Move linked issues to Done
+        if: steps.issues.outputs.issue_numbers != ''
+        run: |
+          PROJECT_NUMBER="${{ steps.project.outputs.project_number }}"
+          PROJECT_ID="${{ steps.metadata.outputs.project_id }}"
+          STATUS_FIELD_ID="${{ steps.metadata.outputs.status_field_id }}"
+          DONE_OPTION_ID="${{ steps.metadata.outputs.done_option_id }}"
+
+          for ISSUE_NUMBER in ${{ steps.issues.outputs.issue_numbers }}; do
+            echo "==> Processing issue #$ISSUE_NUMBER..."
+
+            ISSUE_URL=$(gh issue view "$ISSUE_NUMBER" --json url | jq -r '.url')
+
+            ITEM_ID=$(gh project item-list "$PROJECT_NUMBER" \
+              --owner "$OWNER" \
+              --format json \
+              | jq -r --arg url "$ISSUE_URL" \
+                  '.items[] | select(.content.url == $url) | .id')
+
+            if [[ -z "$ITEM_ID" ]]; then
+              echo "    Issue #$ISSUE_NUMBER not found in project. Adding it first..."
+              ITEM_ID=$(gh project item-add "$PROJECT_NUMBER" \
+                --owner "$OWNER" \
+                --url "$ISSUE_URL" \
+                --format json \
+                | jq -r '.id')
+            fi
+
+            echo "    Moving item $ITEM_ID to Done..."
+            gh project item-edit \
+              --id "$ITEM_ID" \
+              --field-id "$STATUS_FIELD_ID" \
+              --single-select-option-id "$DONE_OPTION_ID" \
+              --project-id "$PROJECT_ID"
+
+            echo "    ✅ Issue #$ISSUE_NUMBER moved to Done"
+          done

--- a/scripts/setup-github-project.sh
+++ b/scripts/setup-github-project.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# setup-github-project.sh
+# One-time setup: creates the GitHub Project, adds Status field, links repo.
+# Run once per repo. Writes project number to .github/project-number.
+#
+# Usage: ./scripts/setup-github-project.sh
+#
+# Pre-requisites:
+#   gh auth refresh -s project   # adds 'project' OAuth scope
+
+set -euo pipefail
+
+OWNER="santi-ap"
+REPO="interval-alarm"
+PROJECT_TITLE="Interval Alarm"
+PROJECT_NUMBER_FILE=".github/project-number"
+
+echo "==> Checking gh auth scopes..."
+if ! gh auth status 2>&1 | grep -q "project"; then
+  echo "ERROR: 'project' OAuth scope is missing."
+  echo "Run: gh auth refresh -s project"
+  exit 1
+fi
+
+echo "==> Checking if project '$PROJECT_TITLE' already exists..."
+EXISTING=$(gh project list --owner "$OWNER" --format json \
+  | jq -r --arg title "$PROJECT_TITLE" '.projects[] | select(.title == $title) | .number')
+
+if [[ -n "$EXISTING" ]]; then
+  echo "Project '$PROJECT_TITLE' already exists (number: $EXISTING). Skipping creation."
+  PROJECT_NUMBER="$EXISTING"
+else
+  echo "==> Creating project '$PROJECT_TITLE'..."
+  PROJECT_NUMBER=$(gh project create \
+    --owner "$OWNER" \
+    --title "$PROJECT_TITLE" \
+    --format json \
+    | jq -r '.number')
+  echo "Created project number: $PROJECT_NUMBER"
+fi
+
+echo "$PROJECT_NUMBER" > "$PROJECT_NUMBER_FILE"
+echo "==> Written project number to $PROJECT_NUMBER_FILE"
+
+echo "==> Fetching project ID..."
+PROJECT_ID=$(gh project list --owner "$OWNER" --format json \
+  | jq -r --argjson num "$PROJECT_NUMBER" '.projects[] | select(.number == $num) | .id')
+
+echo "==> Checking existing fields..."
+FIELDS=$(gh project field-list "$PROJECT_NUMBER" --owner "$OWNER" --format json)
+STATUS_FIELD=$(echo "$FIELDS" | jq -r '.fields[] | select(.name == "Status") | .id')
+
+if [[ -n "$STATUS_FIELD" ]]; then
+  echo "Status field already exists (id: $STATUS_FIELD). Skipping field creation."
+else
+  echo "==> Creating 'Status' single-select field with options..."
+  gh project field-create "$PROJECT_NUMBER" \
+    --owner "$OWNER" \
+    --name "Status" \
+    --data-type "SINGLE_SELECT" \
+    --single-select-options "Todo,In Progress,Done"
+  echo "Status field created."
+fi
+
+echo "==> Linking repo $OWNER/$REPO to project..."
+gh project link "$PROJECT_NUMBER" \
+  --owner "$OWNER" \
+  --repo "$REPO" 2>/dev/null || echo "(Repo may already be linked — continuing)"
+
+echo ""
+echo "✅ Setup complete!"
+echo "   Project: $PROJECT_TITLE"
+echo "   Number:  $PROJECT_NUMBER"
+echo "   File:    $PROJECT_NUMBER_FILE"
+echo ""
+echo "Next steps:"
+echo "  1. Run ./scripts/sync-tasks-to-github.sh   # import existing task files"
+echo "  2. Run ./scripts/start-task.sh <tasks/file.md>   # start working on a task"

--- a/scripts/start-task.sh
+++ b/scripts/start-task.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# start-task.sh
+# Primary daily-use script. Given a tasks/*.md file:
+#   1. Parses the title
+#   2. Finds or creates the GitHub Issue
+#   3. Adds the issue to the project if needed
+#   4. Immediately moves the kanban card to "In Progress"
+#   5. Creates a branch via `gh issue develop`
+#   6. Checks out that branch locally
+#
+# Usage: ./scripts/start-task.sh tasks/bug-fix-same-day-alarm.md
+#
+# Pre-requisites: setup-github-project.sh must have been run first.
+
+set -euo pipefail
+
+OWNER="santi-ap"
+PROJECT_NUMBER_FILE=".github/project-number"
+
+# ── Argument validation ──────────────────────────────────────────────────────
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <tasks/file.md>"
+  exit 1
+fi
+
+TASK_FILE="$1"
+if [[ ! -f "$TASK_FILE" ]]; then
+  echo "ERROR: Task file not found: $TASK_FILE"
+  exit 1
+fi
+
+if [[ ! -f "$PROJECT_NUMBER_FILE" ]]; then
+  echo "ERROR: $PROJECT_NUMBER_FILE not found. Run ./scripts/setup-github-project.sh first."
+  exit 1
+fi
+
+PROJECT_NUMBER=$(cat "$PROJECT_NUMBER_FILE")
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+slugify() {
+  echo "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed 's/[^a-z0-9]/-/g' \
+    | sed 's/-\+/-/g' \
+    | sed 's/^-//;s/-$//'
+}
+
+# ── Parse task file ──────────────────────────────────────────────────────────
+TITLE=$(grep -m1 '^# ' "$TASK_FILE" | sed 's/^# //')
+if [[ -z "$TITLE" ]]; then
+  echo "ERROR: Could not parse title from $TASK_FILE (expected a line starting with '# ')"
+  exit 1
+fi
+
+# Extract context section (lines between "## Context" and the next "##" heading)
+CONTEXT=$(awk '/^## Context/{found=1; next} found && /^## /{exit} found{print}' "$TASK_FILE" | head -5)
+[[ -z "$CONTEXT" ]] && CONTEXT="Tracked from \`$TASK_FILE\`."
+
+TASK_SLUG=$(slugify "$TITLE")
+echo "==> Task:    $TITLE"
+echo "==> File:    $TASK_FILE"
+echo "==> Slug:    $TASK_SLUG"
+echo "==> Project: $PROJECT_NUMBER"
+
+# ── Fetch project metadata ───────────────────────────────────────────────────
+echo ""
+echo "==> Fetching project metadata..."
+PROJECT_ID=$(gh project list --owner "$OWNER" --format json \
+  | jq -r --argjson num "$PROJECT_NUMBER" '.projects[] | select(.number == $num) | .id')
+
+FIELDS=$(gh project field-list "$PROJECT_NUMBER" --owner "$OWNER" --format json)
+STATUS_FIELD_ID=$(echo "$FIELDS" | jq -r '.fields[] | select(.name == "Status") | .id')
+IN_PROGRESS_OPTION_ID=$(echo "$FIELDS" \
+  | jq -r '.fields[] | select(.name == "Status") | .options[] | select(.name == "In Progress") | .id')
+
+if [[ -z "$STATUS_FIELD_ID" || -z "$IN_PROGRESS_OPTION_ID" ]]; then
+  echo "ERROR: Could not find Status field or 'In Progress' option. Run setup-github-project.sh."
+  exit 1
+fi
+
+# ── Find or create the issue ─────────────────────────────────────────────────
+echo ""
+echo "==> Searching for existing issue: '$TITLE'..."
+ISSUE_NUMBER=$(gh issue list \
+  --state all \
+  --search "\"$TITLE\" in:title" \
+  --limit 10 \
+  --json number,title \
+  | jq -r --arg title "$TITLE" '.[] | select(.title == $title) | .number' \
+  | head -1)
+
+if [[ -n "$ISSUE_NUMBER" ]]; then
+  echo "    Found existing issue #$ISSUE_NUMBER"
+else
+  echo "    No existing issue found. Creating..."
+  PR_BODY=$(cat <<EOF
+$CONTEXT
+
+---
+*Tracked from \`$TASK_FILE\`.*
+EOF
+)
+  ISSUE_NUMBER=$(gh issue create \
+    --title "$TITLE" \
+    --body "$PR_BODY" \
+    --json number \
+    | jq -r '.number')
+  echo "    Created issue #$ISSUE_NUMBER"
+fi
+
+ISSUE_URL=$(gh issue view "$ISSUE_NUMBER" --json url | jq -r '.url')
+echo "    URL: $ISSUE_URL"
+
+# ── Add issue to project (idempotent) ────────────────────────────────────────
+echo ""
+echo "==> Adding issue #$ISSUE_NUMBER to project $PROJECT_NUMBER..."
+ITEM_ID=$(gh project item-add "$PROJECT_NUMBER" \
+  --owner "$OWNER" \
+  --url "$ISSUE_URL" \
+  --format json \
+  | jq -r '.id')
+echo "    Project item id: $ITEM_ID"
+
+# ── Move card to "In Progress" immediately ───────────────────────────────────
+echo ""
+echo "==> Moving card to 'In Progress'..."
+gh project item-edit \
+  --id "$ITEM_ID" \
+  --field-id "$STATUS_FIELD_ID" \
+  --single-select-option-id "$IN_PROGRESS_OPTION_ID" \
+  --project-id "$PROJECT_ID"
+echo "    ✅ Card is now In Progress"
+
+# ── Create branch via gh issue develop ──────────────────────────────────────
+BRANCH_NAME="${ISSUE_NUMBER}/${TASK_SLUG}"
+echo ""
+echo "==> Creating branch '$BRANCH_NAME' via 'gh issue develop'..."
+gh issue develop "$ISSUE_NUMBER" \
+  --name "$BRANCH_NAME" \
+  --base master 2>/dev/null || {
+    echo "    (Branch may already exist — attempting to check out anyway)"
+  }
+
+# ── Checkout branch locally ──────────────────────────────────────────────────
+echo "==> Checking out branch '$BRANCH_NAME'..."
+git fetch origin "$BRANCH_NAME" 2>/dev/null || true
+git checkout "$BRANCH_NAME" 2>/dev/null || git checkout -b "$BRANCH_NAME" --track "origin/$BRANCH_NAME" 2>/dev/null || git checkout -b "$BRANCH_NAME"
+
+echo ""
+echo "✅ Ready to work!"
+echo "   Issue:   #$ISSUE_NUMBER — $TITLE"
+echo "   Branch:  $BRANCH_NAME"
+echo "   Card:    In Progress on GitHub Projects"
+echo ""
+echo "When done, open a PR with this in the body:"
+echo "   Closes #$ISSUE_NUMBER"
+echo "That will auto-move the card to 'Done' when the PR merges."

--- a/scripts/sync-tasks-to-github.sh
+++ b/scripts/sync-tasks-to-github.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# sync-tasks-to-github.sh
+# Bulk-imports existing tasks/*.md files into GitHub Projects.
+# - All items checked off ([x] all) → "Done"
+# - Any open items → "Todo"
+#
+# Usage: ./scripts/sync-tasks-to-github.sh
+#
+# Pre-requisites: setup-github-project.sh must have been run first.
+
+set -euo pipefail
+
+OWNER="santi-ap"
+PROJECT_NUMBER_FILE=".github/project-number"
+TASKS_DIR="tasks"
+
+if [[ ! -f "$PROJECT_NUMBER_FILE" ]]; then
+  echo "ERROR: $PROJECT_NUMBER_FILE not found. Run ./scripts/setup-github-project.sh first."
+  exit 1
+fi
+
+PROJECT_NUMBER=$(cat "$PROJECT_NUMBER_FILE")
+echo "==> Using project number: $PROJECT_NUMBER"
+
+# Fetch project ID
+PROJECT_ID=$(gh project list --owner "$OWNER" --format json \
+  | jq -r --argjson num "$PROJECT_NUMBER" '.projects[] | select(.number == $num) | .id')
+
+# Fetch Status field ID and option IDs
+FIELDS=$(gh project field-list "$PROJECT_NUMBER" --owner "$OWNER" --format json)
+STATUS_FIELD_ID=$(echo "$FIELDS" | jq -r '.fields[] | select(.name == "Status") | .id')
+TODO_OPTION_ID=$(echo "$FIELDS" | jq -r '.fields[] | select(.name == "Status") | .options[] | select(.name == "Todo") | .id')
+DONE_OPTION_ID=$(echo "$FIELDS" | jq -r '.fields[] | select(.name == "Status") | .options[] | select(.name == "Done") | .id')
+
+if [[ -z "$STATUS_FIELD_ID" ]]; then
+  echo "ERROR: Status field not found in project. Run ./scripts/setup-github-project.sh first."
+  exit 1
+fi
+
+echo "==> Status field id: $STATUS_FIELD_ID"
+
+# Parse title from a task file (first # heading)
+parse_title() {
+  grep -m1 '^# ' "$1" | sed 's/^# //'
+}
+
+# Determine if all checkboxes are checked (returns "done" or "todo")
+determine_status() {
+  local file="$1"
+  local total unchecked
+  total=$(grep -c '^\s*- \[' "$file" || true)
+  unchecked=$(grep -c '^\s*- \[ \]' "$file" || true)
+  if [[ "$total" -gt 0 && "$unchecked" -eq 0 ]]; then
+    echo "done"
+  else
+    echo "todo"
+  fi
+}
+
+# Existing issues cache (title → number)
+declare -A EXISTING_ISSUES
+while IFS=$'\t' read -r number title; do
+  EXISTING_ISSUES["$title"]="$number"
+done < <(gh issue list --state all --limit 200 --json number,title \
+  | jq -r '.[] | [(.number | tostring), .title] | @tsv')
+
+echo "==> Found ${#EXISTING_ISSUES[@]} existing issues."
+
+for task_file in "$TASKS_DIR"/*.md; do
+  [[ -f "$task_file" ]] || continue
+
+  TITLE=$(parse_title "$task_file")
+  [[ -z "$TITLE" ]] && { echo "SKIP $task_file (no title)"; continue; }
+
+  echo ""
+  echo "--- Processing: $task_file"
+  echo "    Title: $TITLE"
+
+  STATUS=$(determine_status "$task_file")
+  echo "    Status: $STATUS"
+
+  # Find or create the issue
+  if [[ -v "EXISTING_ISSUES[$TITLE]" ]]; then
+    ISSUE_NUMBER="${EXISTING_ISSUES[$TITLE]}"
+    echo "    Issue already exists: #$ISSUE_NUMBER"
+  else
+    echo "    Creating issue..."
+    ISSUE_NUMBER=$(gh issue create \
+      --title "$TITLE" \
+      --body "Tracked from \`$task_file\`." \
+      --json number \
+      | jq -r '.number')
+    echo "    Created issue #$ISSUE_NUMBER"
+  fi
+
+  # Add to project (idempotent — gh returns existing item if already added)
+  echo "    Adding issue #$ISSUE_NUMBER to project..."
+  ITEM_ID=$(gh project item-add "$PROJECT_NUMBER" \
+    --owner "$OWNER" \
+    --url "$(gh issue view "$ISSUE_NUMBER" --json url | jq -r '.url')" \
+    --format json \
+    | jq -r '.id')
+
+  # Set status
+  if [[ "$STATUS" == "done" ]]; then
+    OPTION_ID="$DONE_OPTION_ID"
+  else
+    OPTION_ID="$TODO_OPTION_ID"
+  fi
+
+  echo "    Setting status to '$STATUS' (option: $OPTION_ID)..."
+  gh project item-edit \
+    --id "$ITEM_ID" \
+    --field-id "$STATUS_FIELD_ID" \
+    --single-select-option-id "$OPTION_ID" \
+    --project-id "$PROJECT_ID"
+
+  echo "    ✅ Done: #$ISSUE_NUMBER → $STATUS"
+done
+
+echo ""
+echo "✅ Sync complete!"
+echo "   View project: gh project view $PROJECT_NUMBER --owner $OWNER --web"

--- a/tasks/feat-github-kanban.md
+++ b/tasks/feat-github-kanban.md
@@ -1,0 +1,25 @@
+# ✨ Feature: GitHub Projects Kanban Integration
+
+## Context
+Mirror local `tasks/*.md` files in GitHub Projects as a kanban board.
+Immediate status sync: card moves to `In Progress` the moment work starts locally,
+and to `Done` automatically when a PR is merged.
+
+## Kanban Columns
+`Todo` → `In Progress` → `Done`
+
+---
+
+- [ ] ## Setup
+    - [ ] Create `scripts/setup-github-project.sh` (one-time project creation)
+    - [ ] Create `.github/project-number` (populated by setup script)
+- [ ] ## Scripts
+    - [ ] Create `scripts/sync-tasks-to-github.sh` (bulk import existing tasks)
+    - [ ] Create `scripts/start-task.sh` (primary daily-use script)
+- [ ] ## CI Automation
+    - [ ] Create `.github/workflows/project-automation.yml` (auto-move to Done on merge)
+- [ ] ## Verification
+    - [ ] Run `setup-github-project.sh` → project appears in `gh project list`
+    - [ ] Run `sync-tasks-to-github.sh` → all tasks appear in project
+    - [ ] Run `start-task.sh tasks/bug-fix-same-day-alarm.md` → card moves to In Progress + branch created
+    - [ ] Merge a PR with `Closes #N` → card moves to Done


### PR DESCRIPTION
## Summary
- Adds one-time setup script to create and configure a GitHub Projects board with Todo/In Progress/Done columns
- Adds bulk-import script to sync existing tasks/*.md files as GitHub Issues into the project
- Adds start-task.sh — primary daily script that immediately moves the kanban card to In Progress and creates a linked branch
- Adds CI workflow that auto-moves cards to Done when a PR with Closes #N is merged

## Pre-requisites
- Run: gh auth refresh -s project
- Add a PAT with project write scope as repository secret PROJECT_TOKEN

## Test plan
- [ ] Run setup-github-project.sh → project appears in gh project list
- [ ] Run sync-tasks-to-github.sh → all tasks/*.md files appear as issues in the project
- [ ] Run start-task.sh tasks/bug-fix-same-day-alarm.md → card moves to In Progress, branch created
- [ ] Merge a PR with Closes #N → card auto-moves to Done

🤖 Generated with [Claude Code](https://claude.com/claude-code)